### PR TITLE
feat: docker compose로 변경

### DIFF
--- a/.github/workflows/back-dev.yml
+++ b/.github/workflows/back-dev.yml
@@ -150,7 +150,8 @@ jobs:
           script: |
             cd ${{ secrets.WORKING_DIR }}
             docker pull ${{ secrets.DOCKERHUB_USERNAME }}/new-project:${{ github.sha }}
-            docker compose down --spring
+            docker compose stop spring
+            docker compose rm -f spring
             sed -i -E "s#(${{ secrets.DOCKERHUB_USERNAME }}/new-project:).*#\1${{ github.sha }}#g" docker-compose.yml
             docker compose up -d spring
             docker image prune -f

--- a/.github/workflows/back-dev.yml
+++ b/.github/workflows/back-dev.yml
@@ -148,10 +148,11 @@ jobs:
           password: ${{ secrets.ONPREM_SSH_PASSWORD }}
           port: ${{ secrets.ONPREM_SSH_PORT }}
           script: |
+            cd ${{ secrets.WORKING_DIR }}
             docker pull ${{ secrets.DOCKERHUB_USERNAME }}/new-project:${{ github.sha }}
-            docker stop new-project-container || true
-            docker rm new-project-container || true
-            docker run -d --name new-project-container --env-file ${{ secrets.ENV_FILE_PATH }} -p 8080:8080 --network="host" ${{ secrets.DOCKERHUB_USERNAME }}/new-project:${{ github.sha }}
+            docker compose down --spring
+            sed -i -E "s#(${{ secrets.DOCKERHUB_USERNAME }}/new-project:).*#\1${{ github.sha }}#g" docker-compose.yml
+            docker compose up -d spring
             docker image prune -f
 
       - name: Record deploy end and duration


### PR DESCRIPTION
#3 

백엔드 CICD를 docker compose로 변경합니다.

이미지를 가져오고 sed명령어로 docker compose의 이미지 태그를 변경합니다.
무중단 배포가 아니라, 사용자가 들어오기 전 개선이 필요합니다.